### PR TITLE
Fix typo in README for Typescript snippets link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Read more about this feature in the official [VSCode documentation](https://code
 | background             | Creates an environment object for changing the background of a scene. It should be set on a SceneView and it contains a placeholder for color.                                                                |
 
 
-### [TypeScript snippets](typescript.json)
+### [TypeScript snippets](snippets/typescript.json)
 
 | Prefix                 | Description                                                                                                                                                                                                  |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Noticed the ts snippets link had a typo and was broken, fixed it.