### PR TITLE
Add 2D symbol snippets

### DIFF
--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -184,7 +184,7 @@
   },
   "FeatureReductionCluster": {
     "body": [
-      "const featureReduction = {",
+      "{",
       "  type: \"cluster\",",
       "  clusterRadius: 60,",
       "  clusterMinSize: 16.5,",
@@ -379,7 +379,7 @@
   },
   "PictureFillSymbol": {
     "body": [
-      "const pfs = {",
+      "{",
       "  type: \"picture-fill\",",
       "  url: \"image-url\",",
       "  width: 12,",
@@ -393,7 +393,7 @@
   },
   "PictureMarkerSymbol": {
     "body": [
-      "const pms = {",
+      "{",
       "  type: \"picture-marker\",",
       "  url: \"image-url\",",
       "  height: 12,",
@@ -428,7 +428,7 @@
   },
   "SimpleFillSymbol": {
     "body": [
-      "const sfs = {",
+      "{",
       "  type: \"simple-fill\",",
       "  color: [0, 0, 0, 0.25],",
       "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
@@ -443,7 +443,7 @@
   },
   "SimpleLineSymbol": {
     "body": [
-      "const sls = {",
+      "{",
       "  type: \"simple-line\",",
       "  width: 1,",
       "  color: [255, 255, 255, 1],",
@@ -457,7 +457,7 @@
   },
   "SimpleMarkerSymbol": {
     "body": [
-      "const sms = {",
+      "{",
       "  type: \"simple-marker\",",
       "  color: [255, 255, 255, 0.25],",
       "  size: 12,",

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -1,73 +1,5 @@
 {
-  "Require": {
-    "prefix": "require",
-    "body": [
-      "require([\"esri/Map\", \"esri/views/MapView\",\"dojo/domReady!\"],function(Map, MapView){",
-      "",
-      " });"
-    ],
-    "description": "Simple require example"
-  },
-  "CreateMap": {
-    "prefix": "map",
-    "body": [
-      "var map = new Map({",
-      "\tbasemap: \"${1:streets}\"",
-      "});",
-      "var view = new MapView({",
-      "\tcontainer:${2:\"viewDiv\"},",
-      "\tmap:map,",
-      "\tzoom: ${3: 4},",
-      "\tcenter:${4:[15,65]}",
-      "});"
-    ],
-    "description": "Create map and map view"
-  },
-  "CreateScene": {
-    "prefix": "scene",
-    "body": [
-      "var map = new Map({",
-      "\tbasemap: \"${1:streets}\"",
-      "});",
-      "var view = new SceneView({",
-      "\tcontainer: \"${2:viewDiv}\",",
-      "\tmap:map",
-      "});"
-    ],
-    "description": "Create map and scene view"
-  },
-  "CreateWebMap": {
-    "prefix": "webmap",
-    "body": [
-      "var webmap = new WebMap({",
-      "\tportalItem: {",
-      "\t\tid: \"${1:webmap_id}\"",
-      "\t}",
-      "});",
-      "var view = new MapView({",
-      "\tcontainer: \"${2:viewDiv}\",",
-      "\tmap: webmap",
-      "});"
-    ],
-    "description": "Create web map and a map view"
-  },
-  "CreateWebScene": {
-    "prefix": "webscene",
-    "body": [
-      "var webscene = new WebScene({",
-      "\tportalItem: {",
-      "\t\tid: \"${1:webscene_id}\"",
-      "\t}",
-      "});",
-      "var view = new SceneView({",
-      "\tcontainer: \"${2:viewDiv}\",",
-      "\tmap: webscene",
-      "});"
-    ],
-    "description": "Create web scene and scene view"
-  },
   "Add a layer from a portal item ": {
-    "prefix": "addLayerFromPortalItem",
     "body": [
       "Layer.fromPortalItem({",
       "\tportalItem: {",
@@ -77,36 +9,48 @@
       "\t\tmap.add(layer);",
       "\t});"
     ],
-    "description": "Add a layer from a portal item "
+    "description": "Add a layer from a portal item ",
+    "prefix": "addLayerFromPortalItem"
   },
-  "SimpleRenderer": {
-    "prefix": "simple",
+  "CalloutLarge": {
     "body": [
-      "{",
-      "\ttype: \"simple\",",
-      "\tsymbol: ${1:symbol}",
+      "verticalOffset: {",
+      "\tscreenLength: 40,",
+      "\tmaxWorldLength: 500000,",
+      "\tminWorldLength: 0",
+      "},",
+      "callout: {",
+      "\ttype: \"line\",",
+      "\tsize: ${1:1.5},",
+      "\tcolor: ${2:[255, 255, 255, 0.9]},",
+      "\tborder: {",
+      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
+      "\t}",
       "}"
     ],
-    "description": "Generate a SimpleRenderer"
+    "description": "Generate 3D callouts for world scale",
+    "prefix": "calloutLarge"
   },
-  "UniqueValueRenderer": {
-    "prefix": "uniqueValue",
+  "CalloutSmall": {
     "body": [
-      "{",
-      "\ttype: \"unique-value\",",
-      "\tfield: \"${1:REGION}\",",
-      "\tdefaultSymbol: ${2:symbol},",
-      "\tuniqueValueInfos: [{",
-      "\t\tvalue: \"${3:value}\",",
-      "\t\tsymbol: ${2:symbol},",
-      "\t\tlabel: \"${4:label for the legend}\"",
-      "\t}]",
+      "verticalOffset: {",
+      "\tscreenLength: 20,",
+      "\tmaxWorldLength: 200,",
+      "\tminWorldLength: 20",
+      "},",
+      "callout: {",
+      "\ttype: \"line\",",
+      "\tsize: ${1:1.5},",
+      "\tcolor: ${2:[255, 255, 255, 0.9]},",
+      "\tborder: {",
+      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
+      "\t}",
       "}"
     ],
-    "description": "Generate a UniqueValueRenderer"
+    "description": "Generate 3D callouts for city scale",
+    "prefix": "calloutSmall"
   },
   "ClassBreaksRenderer": {
-    "prefix": "classBreaks",
     "body": [
       "{",
       "\ttype: \"class-breaks\",",
@@ -120,29 +64,10 @@
       "\t}]",
       "}"
     ],
-    "description": "Generate a ClassBreaksRenderer"
-  },
-  "SizeVisualVariable": {
-    "prefix": "sizeVar",
-    "body": [
-      "{",
-      "\ttype: \"size\",",
-      "\tfield: \"${1:POP_POVERTY}\",",
-      "\tnormalizationField: \"${2:POP_TOT}\",",
-      "\taxis: \"height\",",
-      "\tlegendOptions: {",
-      "\t\ttitle: \"${3:% population in poverty by county}\"",
-      "\t},",
-      "\tstops: [",
-      "\t\t{ value: ${4:0.15}, size: ${5:4}, label: \"${6:<15%}\" },",
-      "\t\t{ value: ${7:0.25}, size: ${8:12}, label: \"${9:25%}\" }",
-      "\t]",
-      "}"
-    ],
-    "description": "Generate a SizeVisualVariable."
+    "description": "Generate a ClassBreaksRenderer",
+    "prefix": "classBreaks"
   },
   "ColorVisualVariable": {
-    "prefix": "colorVar",
     "body": [
       "{",
       "\ttype: \"color\",",
@@ -157,10 +82,206 @@
       "\t]",
       "}"
     ],
-    "description": "Generate a ColorVisualVariable with 2 color stops."
+    "description": "Generate a ColorVisualVariable with 2 color stops.",
+    "prefix": "colorVar"
+  },
+  "CreateMap": {
+    "body": [
+      "var map = new Map({",
+      "\tbasemap: \"${1:streets}\"",
+      "});",
+      "var view = new MapView({",
+      "\tcontainer:${2:\"viewDiv\"},",
+      "\tmap:map,",
+      "\tzoom: ${3: 4},",
+      "\tcenter:${4:[15,65]}",
+      "});"
+    ],
+    "description": "Create map and map view",
+    "prefix": "map"
+  },
+  "CreateScene": {
+    "body": [
+      "var map = new Map({",
+      "\tbasemap: \"${1:streets}\"",
+      "});",
+      "var view = new SceneView({",
+      "\tcontainer: \"${2:viewDiv}\",",
+      "\tmap:map",
+      "});"
+    ],
+    "description": "Create map and scene view",
+    "prefix": "scene"
+  },
+  "CreateWebMap": {
+    "body": [
+      "var webmap = new WebMap({",
+      "\tportalItem: {",
+      "\t\tid: \"${1:webmap_id}\"",
+      "\t}",
+      "});",
+      "var view = new MapView({",
+      "\tcontainer: \"${2:viewDiv}\",",
+      "\tmap: webmap",
+      "});"
+    ],
+    "description": "Create web map and a map view",
+    "prefix": "webmap"
+  },
+  "CreateWebScene": {
+    "body": [
+      "var webscene = new WebScene({",
+      "\tportalItem: {",
+      "\t\tid: \"${1:webscene_id}\"",
+      "\t}",
+      "});",
+      "var view = new SceneView({",
+      "\tcontainer: \"${2:viewDiv}\",",
+      "\tmap: webscene",
+      "});"
+    ],
+    "description": "Create web scene and scene view",
+    "prefix": "webscene"
+  },
+  "Edges": {
+    "body": [
+      "{",
+      "\ttype: \"${1|solid,sketch|}\",",
+      "\tcolor: ${2:[50, 50, 50, 0.5]},",
+      "\tsize: ${3:1}",
+      "\textensionLength: ${4:0}",
+      "}"
+    ],
+    "description": "Creates and EdgeSymbol3D",
+    "prefix": "edges"
+  },
+  "ElevationInfo": {
+    "body": [
+      "{",
+      "\tmode: \"${1|on-the-ground,relative-to-ground,absolute-height,relative-to-scene|}\",",
+      "\toffset: ${2:10},",
+      "\tfeatureExpressionInfo: {",
+      "\t\texpression: \"${3:Geometry(\\$feature).z\"}",
+      "\t},",
+      "\tunit: \"${4|feet,meters,kilometers,miles,us-feet,yards|}\"",
+      "}"
+    ],
+    "prefix": "elevInfo"
+  },
+  "ExtrudePolygon3D": {
+    "body": [
+      "{",
+      "\ttype: \"polygon-3d\",",
+      "\tsymbolLayers: [{",
+      "\t\ttype: \"extrude\",",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${2:20}",
+      "\t}]",
+      "}"
+    ],
+    "description": "Generate PolygonSymbol3D with a ExtrudeSymbol3DLayer",
+    "prefix": "extrude"
+  },
+  "FeatureReductionCluster": {
+    "body": [
+      "const featureReduction = {",
+      "  type: \"cluster\",",
+      "  clusterRadius: 60,",
+      "  clusterMinSize: 16.5,",
+      "  clusterMaxSize: 37.5,",
+      "  popupTemplate: {",
+      "    title: \"Cluster summary\",",
+      "    content: \"This cluster represents <b>{cluster_count}</b> features.\",",
+      "    fieldInfos: [{",
+      "      fieldName: \"cluster_count\",",
+      "      label: \"Number of features\",",
+      "      format: {",
+      "        digitSeparator: true,",
+      "        places: 0",
+      "      }",
+      "    }]",
+      "  },",
+      "  popupEnabled: true,",
+      "  labelingInfo: [{",
+      "    deconflictionStrategy: \"none\",",
+      "    labelExpressionInfo: {",
+      "      expression: `",
+      "        \\$feature[\"cluster_count\"];",
+      "        var value = \\$feature[\"cluster_count\"];",
+      "        var num = Count(Text(Round(value)));",
+      "        var label = When(",
+      "          num < 4, Text(value, \"#.#\"),",
+      "          num == 4, Text(value / Pow(10, 3), \"#.0k\"),",
+      "          num <= 6, Text(value / Pow(10, 3), \"#k\"),",
+      "          num == 7, Text(value / Pow(10, 6), \"#.0m\"),",
+      "          num > 7, Text(value / Pow(10, 6), \"#m\"),",
+      "          Text(value, \"#,###\")",
+      "        );",
+      "        return label;",
+      "      `",
+      "    },",
+      "    symbol: {",
+      "      type: \"text\",",
+      "      color: \"rgba(240,240,240,1)\",",
+      "      haloColor: \"rgba(55,56,55,1)\",",
+      "      haloSize: 0.75,",
+      "      font: {",
+      "        weight: \"bold\",",
+      "        family: \"Noto Sans\",",
+      "        size: \"12px\"",
+      "      }",
+      "    },",
+      "    labelPlacement: \"center-center\",",
+      "  }],",
+      "  labelsVisible: true",
+      "}"
+    ],
+    "description": "Enable clustering on a layer",
+    "prefix": "clusterConfig"
+  },
+  "FillMesh3D": {
+    "body": [
+      "{",
+      "\ttype: \"mesh-3d\",",
+      "\tsymbolLayers: [{",
+      "\t\ttype: \"fill\",",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t}]",
+      "}"
+    ],
+    "description": "Generate MeshSymbol3D with a FillSymbol3DLayer",
+    "prefix": "mesh"
+  },
+  "FillPolygon3D": {
+    "body": [
+      "{",
+      "\ttype: \"polygon-3d\",",
+      "\tsymbolLayers: [{",
+      "\t\ttype: \"fill\",",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\toutline: { color: ${2:[70, 70, 70, 0.7]}}",
+      "\t}]",
+      "}"
+    ],
+    "description": "Generate PolygonSymbol3D with a FillSymbol3DLayer",
+    "prefix": "fill"
+  },
+  "IconPoint3D": {
+    "body": [
+      "{",
+      "\ttype: \"point-3d\",",
+      "\tsymbolLayers: [{",
+      "\t\ttype: \"icon\",",
+      "\t\tresource: { primitive: \"${1|circle,square,cross,x,kite,triangle|}\"},",
+      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${3:20}",
+      "\t}]",
+      "}"
+    ],
+    "description": "Generate PointSymbol3D with a IconSymbol3DLayer",
+    "prefix": "icon"
   },
   "LabelingInfo2D": {
-    "prefix": "labeling2d",
     "body": [
       "[",
       "\tnew LabelClass({",
@@ -174,10 +295,10 @@
       "\t})",
       "]"
     ],
-    "description": "Generate 2D labelingInfo for a layer"
+    "description": "Generate 2D labelingInfo for a layer",
+    "prefix": "labeling2d"
   },
   "LabelingInfo3D": {
-    "prefix": "labeling3d",
     "body": [
       "[",
       "\tnew LabelClass({",
@@ -202,26 +323,24 @@
       "\t})",
       "]"
     ],
-    "description": "Generate 3D labelingInfo for a layer"
+    "description": "Generate 3D labelingInfo for a layer",
+    "prefix": "labeling3d"
   },
-  "IconPoint3D": {
-    "prefix": "icon",
+  "Line3D": {
     "body": [
       "{",
-      "\ttype: \"point-3d\",",
+      "\ttype: \"line-3d\",",
       "\tsymbolLayers: [{",
-      "\t\ttype: \"icon\",",
-      "\t\tresource: { primitive: \"${1|circle,square,cross,x,kite,triangle|}\"},",
-      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${3:20}",
+      "\t\ttype: \"line\",",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${2:15}",
       "\t}]",
       "}"
     ],
-    "description": "Generate PointSymbol3D with a IconSymbol3DLayer"
+    "description": "Generate LineSymbol3D with a LineSymbol3DLayer",
+    "prefix": "line"
   },
-
   "ObjectPoint3D": {
-    "prefix": "object",
     "body": [
       "{",
       "\ttype: \"point-3d\",",
@@ -235,26 +354,10 @@
       "\t}]",
       "}"
     ],
-    "description": "Generate PointSymbol3D with a ObjectSymbol3DLayer"
+    "description": "Generate PointSymbol3D with a ObjectSymbol3DLayer",
+    "prefix": "object"
   },
-
-  "Line3D": {
-    "prefix": "line",
-    "body": [
-      "{",
-      "\ttype: \"line-3d\",",
-      "\tsymbolLayers: [{",
-      "\t\ttype: \"line\",",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${2:15}",
-      "\t}]",
-      "}"
-    ],
-    "description": "Generate LineSymbol3D with a LineSymbol3DLayer"
-  },
-
   "Path3D": {
-    "prefix": "path",
     "body": [
       "{",
       "\ttype: \"line-3d\",",
@@ -271,114 +374,45 @@
       "\t}]",
       "}"
     ],
-    "description": "Generate LineSymbol3D with a PathSymbol3DLayer"
+    "description": "Generate LineSymbol3D with a PathSymbol3DLayer",
+    "prefix": "path"
   },
-  "FillPolygon3D": {
-    "prefix": "fill",
+  "PictureFillSymbol": {
     "body": [
-      "{",
-      "\ttype: \"polygon-3d\",",
-      "\tsymbolLayers: [{",
-      "\t\ttype: \"fill\",",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\toutline: { color: ${2:[70, 70, 70, 0.7]}}",
-      "\t}]",
+      "const pfs = {",
+      "  type: \"picture-fill\",",
+      "  url: \"image-url\",",
+      "  width: 12,",
+      "  height: 12,",
+      "  xoffset: 0,",
+      "  yoffset: 0",
       "}"
     ],
-    "description": "Generate PolygonSymbol3D with a FillSymbol3DLayer"
+    "description": "Create a PictureFillSymbol",
+    "prefix": "pfs"
   },
-  "ExtrudePolygon3D": {
-    "prefix": "extrude",
+  "PictureMarkerSymbol": {
     "body": [
-      "{",
-      "\ttype: \"polygon-3d\",",
-      "\tsymbolLayers: [{",
-      "\t\ttype: \"extrude\",",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${2:20}",
-      "\t}]",
+      "const pms = {",
+      "  type: \"picture-marker\",",
+      "  url: \"image-url\",",
+      "  height: 12,",
+      "  width: 12",
       "}"
     ],
-    "description": "Generate PolygonSymbol3D with a ExtrudeSymbol3DLayer"
+    "description": "Create a PictureMarkerSymbol",
+    "prefix": "pms"
   },
-  "FillMesh3D": {
-    "prefix": "mesh",
+  "Require": {
     "body": [
-      "{",
-      "\ttype: \"mesh-3d\",",
-      "\tsymbolLayers: [{",
-      "\t\ttype: \"fill\",",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t}]",
-      "}"
+      "require([\"esri/Map\", \"esri/views/MapView\",\"dojo/domReady!\"],function(Map, MapView){",
+      "",
+      " });"
     ],
-    "description": "Generate MeshSymbol3D with a FillSymbol3DLayer"
-  },
-  "Edges": {
-    "prefix": "edges",
-    "body": [
-      "{",
-      "\ttype: \"${1|solid,sketch|}\",",
-      "\tcolor: ${2:[50, 50, 50, 0.5]},",
-      "\tsize: ${3:1}",
-      "\textensionLength: ${4:0}",
-      "}"
-    ],
-    "description": "Creates and EdgeSymbol3D"
-  },
-  "CalloutSmall": {
-    "prefix": "calloutSmall",
-    "body": [
-      "verticalOffset: {",
-      "\tscreenLength: 20,",
-      "\tmaxWorldLength: 200,",
-      "\tminWorldLength: 20",
-      "},",
-      "callout: {",
-      "\ttype: \"line\",",
-      "\tsize: ${1:1.5},",
-      "\tcolor: ${2:[255, 255, 255, 0.9]},",
-      "\tborder: {",
-      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
-      "\t}",
-      "}"
-    ],
-    "description": "Generate 3D callouts for city scale"
-  },
-  "CalloutLarge": {
-    "prefix": "calloutLarge",
-    "body": [
-      "verticalOffset: {",
-      "\tscreenLength: 40,",
-      "\tmaxWorldLength: 500000,",
-      "\tminWorldLength: 0",
-      "},",
-      "callout: {",
-      "\ttype: \"line\",",
-      "\tsize: ${1:1.5},",
-      "\tcolor: ${2:[255, 255, 255, 0.9]},",
-      "\tborder: {",
-      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
-      "\t}",
-      "}"
-    ],
-    "description": "Generate 3D callouts for world scale"
-  },
-  "ElevationInfo": {
-    "prefix": "elevInfo",
-    "body": [
-      "{",
-      "\tmode: \"${1|on-the-ground,relative-to-ground,absolute-height,relative-to-scene|}\",",
-      "\toffset: ${2:10},",
-      "\tfeatureExpressionInfo: {",
-      "\t\texpression: \"${3:Geometry(\\$feature).z\"}",
-      "\t},",
-      "\tunit: \"${4|feet,meters,kilometers,miles,us-feet,yards|}\"",
-      "}"
-    ]
+    "description": "Simple require example",
+    "prefix": "require"
   },
   "SceneBackground": {
-    "prefix": "background",
     "body": [
       "environment: {",
       "\tbackground: {",
@@ -389,134 +423,97 @@
       "\tatmosphereEnabled: false",
       "}"
     ],
-    "description": "Change the background of a scene"
+    "description": "Change the background of a scene",
+    "prefix": "background"
+  },
+  "SimpleFillSymbol": {
+    "body": [
+      "const sfs = {",
+      "  type: \"simple-fill\",",
+      "  color: [0, 0, 0, 0.25],",
+      "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "}"
+    ],
+    "description": "Create a SimpleFillSymbol",
+    "prefix": "sfs"
+  },
+  "SimpleLineSymbol": {
+    "body": [
+      "const sls = {",
+      "  type: \"simple-line\",",
+      "  width: 1,",
+      "  color: [255, 255, 255, 1],",
+      "  style: \"${1|solid,none,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
+      "  cap: \"${2|round,butt,square|}\",",
+      "  join: \"${3|round,miter,bevel|}\"",
+      "}"
+    ],
+    "description": "Create a SimpleLineSymbol",
+    "prefix": "sls"
   },
   "SimpleMarkerSymbol": {
-		"prefix": "sms",
-		"body": [
-			"const sms = {",
-			"  type: \"simple-marker\",",
-			"  color: [255, 255, 255, 0.25],",
-			"  size: 12,",
-			"  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
-			"  outline: {",
-			"    width: 1,",
-			"    color: [255, 255, 255, 1]",
-			"  }",
-			"}"
-		],
-		"description": "Create a SimpleMarkerSymbol"
-	},
-	"PictureMarkerSymbol": {
-		"prefix": "pms",
-		"body": [
-			"const pms = {",
-			"  type: \"picture-marker\",",
-			"  url: \"image-url\",",
-			"  height: 12,",
-			"  width: 12",
-			"}"
-		],
-		"description": "Create a PictureMarkerSymbol"
-	},
-	"SimpleLineSymbol": {
-		"prefix": "sls",
-		"body": [
-			"const sls = {",
-			"  type: \"simple-line\",",
-			"  width: 1,",
-			"  color: [255, 255, 255, 1],",
-			"  style: \"${1|solid,none,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
-			"  cap: \"${2|round,butt,square|}\",",
-			"  join: \"${3|round,miter,bevel|}\"",
-			"}"
-		],
-		"description": "Create a SimpleLineSymbol"
-	},
-	"SimpleFillSymbol": {
-		"prefix": "sfs",
-		"body": [
-			"const sfs = {",
-			"  type: \"simple-fill\",",
-			"  color: [0, 0, 0, 0.25],",
-			"  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
-			"  outline: {",
-			"    width: 1,",
-			"    color: [255, 255, 255, 1]",
-			"  }",
-			"}"
-		],
-		"description": "Create a SimpleFillSymbol"
-	},
-	"PictureFillSymbol": {
-		"prefix": "pfs",
-		"body": [
-			"const pfs = {",
-			"  type: \"picture-fill\",",
-			"  url: \"image-url\",",
-			"  width: 12,",
-			"  height: 12,",
-			"  xoffset: 0,",
-			"  yoffset: 0",
-			"}"
-		],
-		"description": "Create a PictureFillSymbol"
-	},
-	"FeatureReductionCluster": {
-		"prefix": "clusterConfig",
-		"body": [
-			"const featureReduction = {",
-			"  type: \"cluster\",",
-			"  clusterRadius: 60,",
-			"  clusterMinSize: 16.5,",
-			"  clusterMaxSize: 37.5,",
-			"  popupTemplate: {",
-			"    title: \"Cluster summary\",",
-			"    content: \"This cluster represents <b>{cluster_count}</b> features.\",",
-			"    fieldInfos: [{",
-			"      fieldName: \"cluster_count\",",
-			"      label: \"Number of features\",",
-			"      format: {",
-			"        digitSeparator: true,",
-			"        places: 0",
-			"      }",
-			"    }]",
-			"  },",
-			"  popupEnabled: true,",
-			"  labelingInfo: [{",
-			"    deconflictionStrategy: \"none\",",
-			"    labelExpressionInfo: {",
-			"      expression: `",
-			"        \\$feature[\"cluster_count\"];",
-			"        var value = \\$feature[\"cluster_count\"];",
-			"        var num = Count(Text(Round(value)));",
-			"        var label = When(",
-			"          num < 4, Text(value, \"#.#\"),",
-			"          num == 4, Text(value / Pow(10, 3), \"#.0k\"),",
-			"          num <= 6, Text(value / Pow(10, 3), \"#k\"),",
-			"          num == 7, Text(value / Pow(10, 6), \"#.0m\"),",
-			"          num > 7, Text(value / Pow(10, 6), \"#m\"),",
-			"          Text(value, \"#,###\")",
-			"        );",
-			"        return label;",
-			"      `",
-			"    },",
-			"    symbol: {",
-			"      type: \"text\",",
-			"      color: \"rgba(240,240,240,1)\",",
-			"      haloColor: \"rgba(55,56,55,1)\",",
-			"      haloSize: 0.75,",
-			"      font: {",
-			"        weight: \"bold\",",
-			"        family: \"Noto Sans\",",
-			"        size: \"12px\"",
-			"      }",
-			"    },",
-			"    labelPlacement: \"center-center\",",
-			"  }],",
-			"  labelsVisible: true",
-			"}"
-		],
-		"description": "Enable clustering on a layer"
-	}
+    "body": [
+      "const sms = {",
+      "  type: \"simple-marker\",",
+      "  color: [255, 255, 255, 0.25],",
+      "  size: 12,",
+      "  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "}"
+    ],
+    "description": "Create a SimpleMarkerSymbol",
+    "prefix": "sms"
+  },
+  "SimpleRenderer": {
+    "body": [
+      "{",
+      "\ttype: \"simple\",",
+      "\tsymbol: ${1:symbol}",
+      "}"
+    ],
+    "description": "Generate a SimpleRenderer",
+    "prefix": "simple"
+  },
+  "SizeVisualVariable": {
+    "body": [
+      "{",
+      "\ttype: \"size\",",
+      "\tfield: \"${1:POP_POVERTY}\",",
+      "\tnormalizationField: \"${2:POP_TOT}\",",
+      "\taxis: \"height\",",
+      "\tlegendOptions: {",
+      "\t\ttitle: \"${3:% population in poverty by county}\"",
+      "\t},",
+      "\tstops: [",
+      "\t\t{ value: ${4:0.15}, size: ${5:4}, label: \"${6:<15%}\" },",
+      "\t\t{ value: ${7:0.25}, size: ${8:12}, label: \"${9:25%}\" }",
+      "\t]",
+      "}"
+    ],
+    "description": "Generate a SizeVisualVariable.",
+    "prefix": "sizeVar"
+  },
+  "UniqueValueRenderer": {
+    "body": [
+      "{",
+      "\ttype: \"unique-value\",",
+      "\tfield: \"${1:REGION}\",",
+      "\tdefaultSymbol: ${2:symbol},",
+      "\tuniqueValueInfos: [{",
+      "\t\tvalue: \"${3:value}\",",
+      "\t\tsymbol: ${2:symbol},",
+      "\t\tlabel: \"${4:label for the legend}\"",
+      "\t}]",
+      "}"
+    ],
+    "description": "Generate a UniqueValueRenderer",
+    "prefix": "uniqueValue"
+  }
 }

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -390,5 +390,133 @@
       "}"
     ],
     "description": "Change the background of a scene"
-  }
+  },
+  "SimpleMarkerSymbol": {
+		"prefix": "sms",
+		"body": [
+			"const sms = {",
+			"  type: \"simple-marker\",",
+			"  color: [255, 255, 255, 0.25],",
+			"  size: 12,",
+			"  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
+			"  outline: {",
+			"    width: 1,",
+			"    color: [255, 255, 255, 1]",
+			"  }",
+			"}"
+		],
+		"description": "Create a SimpleMarkerSymbol"
+	},
+	"PictureMarkerSymbol": {
+		"prefix": "pms",
+		"body": [
+			"const pms = {",
+			"  type: \"picture-marker\",",
+			"  url: \"image-url\",",
+			"  height: 12,",
+			"  width: 12",
+			"}"
+		],
+		"description": "Create a PictureMarkerSymbol"
+	},
+	"SimpleLineSymbol": {
+		"prefix": "sls",
+		"body": [
+			"const sls = {",
+			"  type: \"simple-line\",",
+			"  width: 1,",
+			"  color: [255, 255, 255, 1],",
+			"  style: \"${1|solid,none,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
+			"  cap: \"${2|round,butt,square|}\",",
+			"  join: \"${3|round,miter,bevel|}\"",
+			"}"
+		],
+		"description": "Create a SimpleLineSymbol"
+	},
+	"SimpleFillSymbol": {
+		"prefix": "sfs",
+		"body": [
+			"const sfs = {",
+			"  type: \"simple-fill\",",
+			"  color: [0, 0, 0, 0.25],",
+			"  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
+			"  outline: {",
+			"    width: 1,",
+			"    color: [255, 255, 255, 1]",
+			"  }",
+			"}"
+		],
+		"description": "Create a SimpleFillSymbol"
+	},
+	"PictureFillSymbol": {
+		"prefix": "pfs",
+		"body": [
+			"const pfs = {",
+			"  type: \"picture-fill\",",
+			"  url: \"image-url\",",
+			"  width: 12,",
+			"  height: 12,",
+			"  xoffset: 0,",
+			"  yoffset: 0",
+			"}"
+		],
+		"description": "Create a PictureFillSymbol"
+	},
+	"FeatureReductionCluster": {
+		"prefix": "clusterConfig",
+		"body": [
+			"const featureReduction = {",
+			"  type: \"cluster\",",
+			"  clusterRadius: 60,",
+			"  clusterMinSize: 16.5,",
+			"  clusterMaxSize: 37.5,",
+			"  popupTemplate: {",
+			"    title: \"Cluster summary\",",
+			"    content: \"This cluster represents <b>{cluster_count}</b> features.\",",
+			"    fieldInfos: [{",
+			"      fieldName: \"cluster_count\",",
+			"      label: \"Number of features\",",
+			"      format: {",
+			"        digitSeparator: true,",
+			"        places: 0",
+			"      }",
+			"    }]",
+			"  },",
+			"  popupEnabled: true,",
+			"  labelingInfo: [{",
+			"    deconflictionStrategy: \"none\",",
+			"    labelExpressionInfo: {",
+			"      expression: `",
+			"        \\$feature[\"cluster_count\"];",
+			"        var value = \\$feature[\"cluster_count\"];",
+			"        var num = Count(Text(Round(value)));",
+			"        var label = When(",
+			"          num < 4, Text(value, \"#.#\"),",
+			"          num == 4, Text(value / Pow(10, 3), \"#.0k\"),",
+			"          num <= 6, Text(value / Pow(10, 3), \"#k\"),",
+			"          num == 7, Text(value / Pow(10, 6), \"#.0m\"),",
+			"          num > 7, Text(value / Pow(10, 6), \"#m\"),",
+			"          Text(value, \"#,###\")",
+			"        );",
+			"        return label;",
+			"      `",
+			"    },",
+			"    symbol: {",
+			"      type: \"text\",",
+			"      color: \"rgba(240,240,240,1)\",",
+			"      haloColor: \"rgba(55,56,55,1)\",",
+			"      haloSize: 0.75,",
+			"      font: {",
+			"        weight: \"bold\",",
+			"        family: \"Noto Sans\",",
+			"        size: \"12px\"",
+			"      }",
+			"    },",
+			"    labelPlacement: \"center-center\",",
+			"  }],",
+			"  labelsVisible: true",
+			"}"
+		],
+		"description": "Enable clustering on a layer"
+	}
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -240,14 +240,14 @@
     "body": [
       "new LineSymbol3D({",
       "\tsymbolLayers: [new PathSymbol3DLayer({",
-        "\t\tprofile: \"${1|circle,quad|}\",",
-        "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
-        "\t\twidth: ${3:15},",
-        "\t\theight: ${3:15},",
-        "\t\tjoin: \"${4|miter,bevel,round|}\",",
-        "\t\tcap: \"${5|butt,square,round,none|}\",",
-        "\t\tanchor: \"${6|bottom,center|}\",",
-        "\t\tprofileRotation: \"${7|all,heading|}\"",
+      "\t\tprofile: \"${1|circle,quad|}\",",
+      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
+      "\t\twidth: ${3:15},",
+      "\t\theight: ${3:15},",
+      "\t\tjoin: \"${4|miter,bevel,round|}\",",
+      "\t\tcap: \"${5|butt,square,round,none|}\",",
+      "\t\tanchor: \"${6|bottom,center|}\",",
+      "\t\tprofileRotation: \"${7|all,heading|}\"",
       "\t})]",
       "})"
     ],
@@ -298,7 +298,6 @@
       "})"
     ]
   },
-
   "SolidEdges": {
     "prefix": "solidEdges",
     "body": [
@@ -308,7 +307,6 @@
       "})"
     ]
   },
-
   "CalloutSmall": {
     "prefix": "calloutSmall",
     "body": [
@@ -328,7 +326,6 @@
     ],
     "description": "Generate callouts for city scale"
   },
-
   "CalloutLarge": {
     "prefix": "calloutLarge",
     "body": [
@@ -375,5 +372,125 @@
       "}"
     ],
     "description": "Change the background of a scene"
+  },
+  "SimpleMarkerSymbol": {
+    "prefix": "sms",
+    "body": [
+      "const sms = new SimpleMarkerSymbol({",
+      "  color: [255, 255, 255, 0.25],",
+      "  size: 12,",
+      "  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "});"
+    ],
+    "description": "Create a SimpleMarkerSymbol"
+  },
+  "PictureMarkerSymbol": {
+    "prefix": "pms",
+    "body": [
+      "const pms = new PictureMarkerSymbol({",
+      "  url: \"image-url\",",
+      "  height: 12,",
+      "  width: 12",
+      "});"
+    ],
+    "description": "Create a PictureMarkerSymbol"
+  },
+  "SimpleLineSymbol": {
+    "prefix": "sls",
+    "body": [
+      "const sls = new SimpleLineSymbol({",
+      "  width: 1,",
+      "  color: [255, 255, 255, 1],",
+      "  style: \"${1|solid,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,none,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
+      "  cap: \"${2|round,butt,square|}\",",
+      "  join: \"${3|round,miter,bevel|}\"",
+      "});"
+    ],
+    "description": "Create a SimpleLineSymbol"
+  },
+  "SimpleFillSymbol": {
+    "prefix": "sfs",
+    "body": [
+      "const sfs = new SimpleFillSymbol({",
+      "  color: [0, 0, 0, 0.25],",
+      "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "});"
+    ],
+    "description": "Create a SimpleFillSymbol"
+  },
+  "PictureFillSymbol": {
+    "prefix": "pfs",
+    "body": [
+      "const pfs = new PictureFillSymbol({",
+      "  url: \"image-url\",",
+      "  width: 12,",
+      "  height: 12,",
+      "  xoffset: 0,",
+      "  yoffset: 0",
+      "});"
+    ]
+  },
+  "FeatureReductionCluster": {
+    "prefix": "clusterConfig",
+    "body": [
+      "const featureReduction = new FeatureReductionCluster({",
+      "  clusterRadius: 60,",
+      "  clusterMinSize: 16.5,",
+      "  clusterMaxSize: 37.5,",
+      "  popupTemplate: new PopupTemplate({",
+      "    title: \"Cluster summary\",",
+      "    content: \"This cluster represents <b>{cluster_count}</b> features.\",",
+      "    fieldInfos: [{",
+      "      fieldName: \"cluster_count\",",
+      "      label: \"Number of features\",",
+      "      format: {",
+      "        digitSeparator: true,",
+      "        places: 0",
+      "      }",
+      "    }]",
+      "  }),",
+      "  popupEnabled: true,",
+      "  labelingInfo: [new LabelClass({",
+      "    deconflictionStrategy: \"none\",",
+      "    labelExpressionInfo: {",
+      "      expression: `",
+      "        \\$feature[\"cluster_count\"];",
+      "        var value = \\$feature[\"cluster_count\"];",
+      "        var num = Count(Text(Round(value)));",
+      "        var label = When(",
+      "          num < 4, Text(value, \"#.#\"),",
+      "          num == 4, Text(value / Pow(10, 3), \"#.0k\"),",
+      "          num <= 6, Text(value / Pow(10, 3), \"#k\"),",
+      "          num == 7, Text(value / Pow(10, 6), \"#.0m\"),",
+      "          num > 7, Text(value / Pow(10, 6), \"#m\"),",
+      "          Text(value, \"#,###\")",
+      "        );",
+      "        return label;",
+      "      `",
+      "    },",
+      "    symbol: new TextSymbol({",
+      "      color: \"rgba(240,240,240,1)\",",
+      "      haloColor: \"rgba(55,56,55,1)\",",
+      "      haloSize: 0.75,",
+      "      font: {",
+      "        weight: \"bold\",",
+      "        family: \"Noto Sans\",",
+      "        size: \"12px\"",
+      "      }",
+      "    }),",
+      "    labelPlacement: \"center-center\",",
+      "  })],",
+      "  labelsVisible: true",
+      "});"
+    ],
+    "description": "Enable clustering on a layer"
   }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -1,72 +1,5 @@
 {
-  "CreateMap": {
-    "prefix": "map",
-    "body": [
-      "import Map = require(\"esri/Map\");",
-      "import MapView = require(\"esri/views/MapView\");",
-      "const map = new Map({",
-      "\tbasemap: \"${1:streets}\"",
-      "});",
-      "const view = new MapView({",
-      "\tmap,",
-      "\tcontainer:\"viewDiv\",",
-      "\tcenter:[${2: -118.244,34.052}],",
-      "\tzoom:${3:12}",
-      "});"
-    ],
-    "description": "Create Map"
-  },
-  "CreateScene": {
-    "prefix": "scene",
-    "body": [
-      "import Map = require(\"esri/Map\");",
-      "import SceneView = require(\"esri/views/SceneView\");",
-      "const map = new Map({",
-      "\tbasemap:\"${1:streets}\"",
-      "});",
-      "const view = new SceneView({",
-      "\tmap,",
-      "\tcontainer:\"viewDiv\"",
-      "});"
-    ],
-    "description": "Create Scene"
-  },
-  "CreateWebMap": {
-    "prefix": "webmap",
-    "body": [
-      "import WebMap = require(\"esri/WebMap\");",
-      "import MapView = require(\"esri/views/MapView\");",
-      "const map = new WebMap({",
-      "\tportalItem:{",
-      "\t\tid: \"${1:6a7794164bc3428692fa771cd04c0d4b}\"",
-      "\t}",
-      "});",
-      "const view = new MapView({",
-      "\tmap,",
-      "\tcontainer:\"${2:viewDiv}\"",
-      "});"
-    ],
-    "description": "Create Web Map"
-  },
-  "CreateWebScene": {
-    "prefix": "webscene",
-    "body": [
-      "import WebScene = require(\"esri/WebScene\");",
-      "import SceneView = require(\"esri/views/SceneView\");",
-      "const map = new WebScene({",
-      "\tportalItem:{",
-      "\t\tid: \"${1:3a9976baef9240ab8645ee25c7e9c096}\"",
-      "\t}",
-      "});",
-      "const view = new SceneView({",
-      "\tmap,",
-      "\tcontainer:\"${2:viewDiv}\"",
-      "});"
-    ],
-    "description": "Create Web Scene"
-  },
   "Add a layer from a portal item ": {
-    "prefix": "addLayerFromPortalItem",
     "body": [
       "Layer.fromPortalItem({",
       "\tportalItem: new PortalItem({",
@@ -76,258 +9,10 @@
       "\t\tmap.add(layer);",
       "\t});"
     ],
-    "description": "Add a layer from a portal item "
-  },
-  "SimpleRenderer": {
-    "prefix": "simple",
-    "body": [
-      "new SimpleRenderer({",
-      "\tsymbol: ${1:symbol}",
-      "})"
-    ],
-    "description": "Generate a SimpleRenderer"
-  },
-  "UniqueValueRenderer": {
-    "prefix": "uniqueValue",
-    "body": [
-      "new UniqueValueRenderer({",
-      "\tfield: \"${1:REGION}\",",
-      "\tdefaultSymbol: ${2:symbol},",
-      "\tuniqueValueInfos: [{",
-      "\t\tvalue: \"${3:value}\",",
-      "\t\tsymbol: ${2:symbol},",
-      "\t\tlabel: \"${4:label for the legend}\"",
-      "\t}]",
-      "})"
-    ],
-    "description": "Generate a UniqueValueRenderer"
-  },
-  "ClassBreaksRenderer": {
-    "prefix": "classBreaks",
-    "body": [
-      "new ClassBreaksRenderer({",
-      "\tfield: \"${1:MAGNITUDE}\",",
-      "\tdefaultSymbol: ${2:symbol},",
-      "\tclassBreakInfos: [{",
-      "\t\tminValue: ${3:0},",
-      "\t\tmaxValue: ${4:10},",
-      "\t\tsymbol: ${2:symbol},",
-      "\t\tlabel: \"${5:label for the legend}\"",
-      "\t}]",
-      "})"
-    ],
-    "description": "Generate a ClassBreaksRenderer"
-  },
-  "SizeVisualVariable": {
-    "prefix": "sizeVar",
-    "body": [
-      "new SizeVariable({",
-      "\tfield: \"${1:POP_POVERTY}\",",
-      "\tnormalizationField: \"${2:POP_TOT}\",",
-      "\taxis: \"height\",",
-      "\tlegendOptions: {",
-      "\t\ttitle: \"${3:% population in poverty by county}\"",
-      "\t},",
-      "\tstops: [",
-      "\t\t{ value: ${4:0.15}, size: ${5:4}, label: \"${6:<15%}\" },",
-      "\t\t{ value: ${7:0.25}, size: ${8:12}, label: \"${9:25%}\" }",
-      "\t]",
-      "})"
-    ],
-    "description": "Generate a SizeVisualVariable."
-  },
-  "ColorVisualVariable": {
-    "prefix": "colorVar",
-    "body": [
-      "new SizeVariable({",
-      "\tfield: \"${1:POP_POVERTY}\",",
-      "\tnormalizationField: \"${2:POP_TOT}\",",
-      "\tlegendOptions: {",
-      "\t\ttitle: \"${3:% population in poverty by county}\"",
-      "\t},",
-      "\tstops: [",
-      "\t\t{ value: ${4:0.15}, color: ${5: \"#FFFCD4\" }, label: \"${6:<15%}\" },",
-      "\t\t{ value: ${7:0.25}, color: ${8: \"#0D2644\"}, label: \"${9:>25%}\" }",
-      "\t]",
-      "}"
-    ],
-    "description": "Generate a ColorVisualVariable."
-  },
-  "LabelingInfo2D": {
-    "prefix": "labeling2d",
-    "body": [
-      "[",
-      "\tnew LabelClass({",
-      "\t\tlabelExpressionInfo: { expression: \"${1:\\$feature.NAME}\"},",
-      "\t\tsymbol: new TextSymbol({",
-      "\t\t\tcolor: ${2:[0, 0, 0, 0.5]},",
-      "\t\t\thaloSize: ${3:1},",
-      "\t\t\thaloColor: ${4:[255, 255, 255, 0.9]}",
-      "\t\t})",
-      "\t})",
-      "]"
-    ],
-    "description": "Generate 2D labelingInfo for a layer"
-  },
-  "LabelingInfo3D": {
-    "prefix": "labeling3d",
-    "body": [
-      "[",
-      "\tnew LabelClass({",
-      "\t\tlabelExpressionInfo: { expression: \"${1:\\$feature.NAME}\"},",
-      "\t\tsymbol: new LabelSymbol3D({",
-      "\t\t\tsymbolLayers: [new TextSymbol3DLayer({",
-      "\t\t\t\tmaterial: {",
-      "\t\t\t\t\tcolor: ${2:[0, 0, 0, 0.5]}",
-      "\t\t\t\t},",
-      "\t\t\t\thalo: {",
-      "\t\t\t\t\tsize: ${3: 1},",
-      "\t\t\t\t\tcolor: ${4:[255, 255, 255, 0.9]}",
-      "\t\t\t\t},",
-      "\t\t\t\tfont: {",
-      "\t\t\t\t\tsize: ${5: 11},",
-      "\t\t\t\t\tfamily: ${6:\"sans-serif\"}",
-      "\t\t\t\t}",
-      "\t\t\t})]",
-      "\t\t})",
-      "\t})",
-      "]"
-    ],
-    "description": "Generate 3D labelingInfo for a layer"
-  },
-  "IconPoint3D": {
-    "prefix": "icon",
-    "body": [
-      "new PointSymbol3D({",
-      "\tsymbolLayers: [new IconSymbol3DLayer({",
-      "\t\tresource: { primitive: \"${1|circle,square,cross,x,kite,triangle|}\"},",
-      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${3:20}",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate PointSymbol3D with a IconSymbol3DLayer"
-  },
-  "ObjectPoint3D": {
-    "prefix": "object",
-    "body": [
-      "new PointSymbol3D({",
-      "\tsymbolLayers: [new ObjectSymbol3DLayer({",
-      "\t\tresource: { primitive: \"${1|sphere,cylinder,cube,cone,inverted-cone,diamond,tetrahedron|}\"},",
-      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
-      "\t\tdepth: ${3:15},",
-      "\t\theight: ${4:20},",
-      "\t\twidth: ${5:5}",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate PointSymbol3D with a ObjectSymbol3DLayer"
-  },
-  "Line3D": {
-    "prefix": "line",
-    "body": [
-      "new LineSymbol3D({",
-      "\tsymbolLayers: [new LineSymbol3DLayer({",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${2:15}",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate LineSymbol3D with a LineSymbol3DLayer"
-  },
-  "Path3D": {
-    "prefix": "path",
-    "body": [
-      "new LineSymbol3D({",
-      "\tsymbolLayers: [new PathSymbol3DLayer({",
-      "\t\tprofile: \"${1|circle,quad|}\",",
-      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
-      "\t\twidth: ${3:15},",
-      "\t\theight: ${3:15},",
-      "\t\tjoin: \"${4|miter,bevel,round|}\",",
-      "\t\tcap: \"${5|butt,square,round,none|}\",",
-      "\t\tanchor: \"${6|bottom,center|}\",",
-      "\t\tprofileRotation: \"${7|all,heading|}\"",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate LineSymbol3D with a PathSymbol3DLayer"
-  },
-  "FillPolygon3D": {
-    "prefix": "fill",
-    "body": [
-      "new PolygonSymbol3D({",
-      "\tsymbolLayers: [ new FillSymbol3DLayer({",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\toutline: { color: ${2:[70, 70, 70, 0.7]}}",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate PolygonSymbol3D with a FillSymbol3DLayer"
-  },
-  "ExtrudePolygon3D": {
-    "prefix": "extrude",
-    "body": [
-      "new PolygonSymbol3D({",
-      "\tsymbolLayers: [ new ExtrudeSymbol3DLayer({",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t\tsize: ${2:20}",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate PolygonSymbol3D with a ExtrudeSymbol3DLayer"
-  },
-  "FillMesh3D": {
-    "prefix": "mesh",
-    "body": [
-      "new MeshSymbol3D({",
-      "\tsymbolLayers: [ new FillSymbol3DLayer({",
-      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
-      "\t})]",
-      "})"
-    ],
-    "description": "Generate MeshSymbol3D with a FillSymbol3DLayer"
-  },
-  "SketchEdges": {
-    "prefix": "sketchEdges",
-    "body": [
-      "new SketchEdges3D({",
-      "\tcolor: ${1:[50, 50, 50, 0.5]},",
-      "\tsize: ${2:1},",
-      "\textensionLength: ${3:0}",
-      "})"
-    ]
-  },
-  "SolidEdges": {
-    "prefix": "solidEdges",
-    "body": [
-      "new SolidEdges3D({",
-      "\tcolor: ${1:[50, 50, 50, 0.5]},",
-      "\tsize: ${2:1}",
-      "})"
-    ]
-  },
-  "CalloutSmall": {
-    "prefix": "calloutSmall",
-    "body": [
-      "verticalOffset: {",
-      "\tscreenLength: 20,",
-      "\tmaxWorldLength: 200,",
-      "\tminWorldLength: 20",
-      "},",
-      "callout: {",
-      "\ttype: \"line\",",
-      "\tsize: ${1:1.5},",
-      "\tcolor: ${2:[255, 255, 255, 0.9]},",
-      "\tborder: {",
-      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
-      "\t}",
-      "}"
-    ],
-    "description": "Generate callouts for city scale"
+    "description": "Add a layer from a portal item ",
+    "prefix": "addLayerFromPortalItem"
   },
   "CalloutLarge": {
-    "prefix": "calloutLarge",
     "body": [
       "verticalOffset: {",
       "\tscreenLength: 40,",
@@ -343,10 +28,128 @@
       "\t}",
       "}"
     ],
-    "description": "Generate callouts for world scale"
+    "description": "Generate callouts for world scale",
+    "prefix": "calloutLarge"
+  },
+  "CalloutSmall": {
+    "body": [
+      "verticalOffset: {",
+      "\tscreenLength: 20,",
+      "\tmaxWorldLength: 200,",
+      "\tminWorldLength: 20",
+      "},",
+      "callout: {",
+      "\ttype: \"line\",",
+      "\tsize: ${1:1.5},",
+      "\tcolor: ${2:[255, 255, 255, 0.9]},",
+      "\tborder: {",
+      "\t\tcolor: ${3:[0, 0, 0, 0.5]}",
+      "\t}",
+      "}"
+    ],
+    "description": "Generate callouts for city scale",
+    "prefix": "calloutSmall"
+  },
+  "ClassBreaksRenderer": {
+    "body": [
+      "new ClassBreaksRenderer({",
+      "\tfield: \"${1:MAGNITUDE}\",",
+      "\tdefaultSymbol: ${2:symbol},",
+      "\tclassBreakInfos: [{",
+      "\t\tminValue: ${3:0},",
+      "\t\tmaxValue: ${4:10},",
+      "\t\tsymbol: ${2:symbol},",
+      "\t\tlabel: \"${5:label for the legend}\"",
+      "\t}]",
+      "})"
+    ],
+    "description": "Generate a ClassBreaksRenderer",
+    "prefix": "classBreaks"
+  },
+  "ColorVisualVariable": {
+    "body": [
+      "new SizeVariable({",
+      "\tfield: \"${1:POP_POVERTY}\",",
+      "\tnormalizationField: \"${2:POP_TOT}\",",
+      "\tlegendOptions: {",
+      "\t\ttitle: \"${3:% population in poverty by county}\"",
+      "\t},",
+      "\tstops: [",
+      "\t\t{ value: ${4:0.15}, color: ${5: \"#FFFCD4\" }, label: \"${6:<15%}\" },",
+      "\t\t{ value: ${7:0.25}, color: ${8: \"#0D2644\"}, label: \"${9:>25%}\" }",
+      "\t]",
+      "}"
+    ],
+    "description": "Generate a ColorVisualVariable.",
+    "prefix": "colorVar"
+  },
+  "CreateMap": {
+    "body": [
+      "import Map = require(\"esri/Map\");",
+      "import MapView = require(\"esri/views/MapView\");",
+      "const map = new Map({",
+      "\tbasemap: \"${1:streets}\"",
+      "});",
+      "const view = new MapView({",
+      "\tmap,",
+      "\tcontainer:\"viewDiv\",",
+      "\tcenter:[${2: -118.244,34.052}],",
+      "\tzoom:${3:12}",
+      "});"
+    ],
+    "description": "Create Map",
+    "prefix": "map"
+  },
+  "CreateScene": {
+    "body": [
+      "import Map = require(\"esri/Map\");",
+      "import SceneView = require(\"esri/views/SceneView\");",
+      "const map = new Map({",
+      "\tbasemap:\"${1:streets}\"",
+      "});",
+      "const view = new SceneView({",
+      "\tmap,",
+      "\tcontainer:\"viewDiv\"",
+      "});"
+    ],
+    "description": "Create Scene",
+    "prefix": "scene"
+  },
+  "CreateWebMap": {
+    "body": [
+      "import WebMap = require(\"esri/WebMap\");",
+      "import MapView = require(\"esri/views/MapView\");",
+      "const map = new WebMap({",
+      "\tportalItem:{",
+      "\t\tid: \"${1:6a7794164bc3428692fa771cd04c0d4b}\"",
+      "\t}",
+      "});",
+      "const view = new MapView({",
+      "\tmap,",
+      "\tcontainer:\"${2:viewDiv}\"",
+      "});"
+    ],
+    "description": "Create Web Map",
+    "prefix": "webmap"
+  },
+  "CreateWebScene": {
+    "body": [
+      "import WebScene = require(\"esri/WebScene\");",
+      "import SceneView = require(\"esri/views/SceneView\");",
+      "const map = new WebScene({",
+      "\tportalItem:{",
+      "\t\tid: \"${1:3a9976baef9240ab8645ee25c7e9c096}\"",
+      "\t}",
+      "});",
+      "const view = new SceneView({",
+      "\tmap,",
+      "\tcontainer:\"${2:viewDiv}\"",
+      "});"
+    ],
+    "description": "Create Web Scene",
+    "prefix": "webscene"
   },
   "ElevationInfo": {
-    "prefix": "elevInfo",
     "body": [
       "{",
       "\tmode: \"${1|on-the-ground,relative-to-ground,absolute-height,relative-to-scene|}\",",
@@ -357,89 +160,22 @@
       "\tunit: \"${4|feet,meters,kilometers,miles,us-feet,yards|}\"",
       "}"
     ],
-    "description": "Set elevationInfo for a layer"
+    "description": "Set elevationInfo for a layer",
+    "prefix": "elevInfo"
   },
-  "SceneBackground": {
-    "prefix": "background",
+  "ExtrudePolygon3D": {
     "body": [
-      "environment: {",
-      "\tbackground: {",
-      "\t\ttype: \"color\",",
-      "\t\tcolor: ${1:[0, 0, 0, 0]}",
-      "\t},",
-      "\tstarsEnabled: false,",
-      "\tatmosphereEnabled: false",
-      "}"
+      "new PolygonSymbol3D({",
+      "\tsymbolLayers: [ new ExtrudeSymbol3DLayer({",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${2:20}",
+      "\t})]",
+      "})"
     ],
-    "description": "Change the background of a scene"
-  },
-  "SimpleMarkerSymbol": {
-    "prefix": "sms",
-    "body": [
-      "const sms = new SimpleMarkerSymbol({",
-      "  color: [255, 255, 255, 0.25],",
-      "  size: 12,",
-      "  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
-      "  outline: {",
-      "    width: 1,",
-      "    color: [255, 255, 255, 1]",
-      "  }",
-      "});"
-    ],
-    "description": "Create a SimpleMarkerSymbol"
-  },
-  "PictureMarkerSymbol": {
-    "prefix": "pms",
-    "body": [
-      "const pms = new PictureMarkerSymbol({",
-      "  url: \"image-url\",",
-      "  height: 12,",
-      "  width: 12",
-      "});"
-    ],
-    "description": "Create a PictureMarkerSymbol"
-  },
-  "SimpleLineSymbol": {
-    "prefix": "sls",
-    "body": [
-      "const sls = new SimpleLineSymbol({",
-      "  width: 1,",
-      "  color: [255, 255, 255, 1],",
-      "  style: \"${1|solid,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,none,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
-      "  cap: \"${2|round,butt,square|}\",",
-      "  join: \"${3|round,miter,bevel|}\"",
-      "});"
-    ],
-    "description": "Create a SimpleLineSymbol"
-  },
-  "SimpleFillSymbol": {
-    "prefix": "sfs",
-    "body": [
-      "const sfs = new SimpleFillSymbol({",
-      "  color: [0, 0, 0, 0.25],",
-      "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
-      "  outline: {",
-      "    width: 1,",
-      "    color: [255, 255, 255, 1]",
-      "  }",
-      "});"
-    ],
-    "description": "Create a SimpleFillSymbol"
-  },
-  "PictureFillSymbol": {
-    "prefix": "pfs",
-    "body": [
-      "const pfs = new PictureFillSymbol({",
-      "  url: \"image-url\",",
-      "  width: 12,",
-      "  height: 12,",
-      "  xoffset: 0,",
-      "  yoffset: 0",
-      "});"
-    ]
+    "description": "Generate PolygonSymbol3D with a ExtrudeSymbol3DLayer",
+    "prefix": "extrude"
   },
   "FeatureReductionCluster": {
-    "prefix": "clusterConfig",
     "body": [
       "const featureReduction = new FeatureReductionCluster({",
       "  clusterRadius: 60,",
@@ -491,6 +227,270 @@
       "  labelsVisible: true",
       "});"
     ],
-    "description": "Enable clustering on a layer"
+    "description": "Enable clustering on a layer",
+    "prefix": "clusterConfig"
+  },
+  "FillMesh3D": {
+    "body": [
+      "new MeshSymbol3D({",
+      "\tsymbolLayers: [ new FillSymbol3DLayer({",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate MeshSymbol3D with a FillSymbol3DLayer",
+    "prefix": "mesh"
+  },
+  "FillPolygon3D": {
+    "body": [
+      "new PolygonSymbol3D({",
+      "\tsymbolLayers: [ new FillSymbol3DLayer({",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\toutline: { color: ${2:[70, 70, 70, 0.7]}}",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate PolygonSymbol3D with a FillSymbol3DLayer",
+    "prefix": "fill"
+  },
+  "IconPoint3D": {
+    "body": [
+      "new PointSymbol3D({",
+      "\tsymbolLayers: [new IconSymbol3DLayer({",
+      "\t\tresource: { primitive: \"${1|circle,square,cross,x,kite,triangle|}\"},",
+      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${3:20}",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate PointSymbol3D with a IconSymbol3DLayer",
+    "prefix": "icon"
+  },
+  "LabelingInfo2D": {
+    "body": [
+      "[",
+      "\tnew LabelClass({",
+      "\t\tlabelExpressionInfo: { expression: \"${1:\\$feature.NAME}\"},",
+      "\t\tsymbol: new TextSymbol({",
+      "\t\t\tcolor: ${2:[0, 0, 0, 0.5]},",
+      "\t\t\thaloSize: ${3:1},",
+      "\t\t\thaloColor: ${4:[255, 255, 255, 0.9]}",
+      "\t\t})",
+      "\t})",
+      "]"
+    ],
+    "description": "Generate 2D labelingInfo for a layer",
+    "prefix": "labeling2d"
+  },
+  "LabelingInfo3D": {
+    "body": [
+      "[",
+      "\tnew LabelClass({",
+      "\t\tlabelExpressionInfo: { expression: \"${1:\\$feature.NAME}\"},",
+      "\t\tsymbol: new LabelSymbol3D({",
+      "\t\t\tsymbolLayers: [new TextSymbol3DLayer({",
+      "\t\t\t\tmaterial: {",
+      "\t\t\t\t\tcolor: ${2:[0, 0, 0, 0.5]}",
+      "\t\t\t\t},",
+      "\t\t\t\thalo: {",
+      "\t\t\t\t\tsize: ${3: 1},",
+      "\t\t\t\t\tcolor: ${4:[255, 255, 255, 0.9]}",
+      "\t\t\t\t},",
+      "\t\t\t\tfont: {",
+      "\t\t\t\t\tsize: ${5: 11},",
+      "\t\t\t\t\tfamily: ${6:\"sans-serif\"}",
+      "\t\t\t\t}",
+      "\t\t\t})]",
+      "\t\t})",
+      "\t})",
+      "]"
+    ],
+    "description": "Generate 3D labelingInfo for a layer",
+    "prefix": "labeling3d"
+  },
+  "Line3D": {
+    "body": [
+      "new LineSymbol3D({",
+      "\tsymbolLayers: [new LineSymbol3DLayer({",
+      "\t\tmaterial: { color: ${1:[255, 250, 239, 0.8]} },",
+      "\t\tsize: ${2:15}",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate LineSymbol3D with a LineSymbol3DLayer",
+    "prefix": "line"
+  },
+  "ObjectPoint3D": {
+    "body": [
+      "new PointSymbol3D({",
+      "\tsymbolLayers: [new ObjectSymbol3DLayer({",
+      "\t\tresource: { primitive: \"${1|sphere,cylinder,cube,cone,inverted-cone,diamond,tetrahedron|}\"},",
+      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
+      "\t\tdepth: ${3:15},",
+      "\t\theight: ${4:20},",
+      "\t\twidth: ${5:5}",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate PointSymbol3D with a ObjectSymbol3DLayer",
+    "prefix": "object"
+  },
+  "Path3D": {
+    "body": [
+      "new LineSymbol3D({",
+      "\tsymbolLayers: [new PathSymbol3DLayer({",
+      "\t\tprofile: \"${1|circle,quad|}\",",
+      "\t\tmaterial: { color: ${2:[255, 250, 239, 0.8]} },",
+      "\t\twidth: ${3:15},",
+      "\t\theight: ${3:15},",
+      "\t\tjoin: \"${4|miter,bevel,round|}\",",
+      "\t\tcap: \"${5|butt,square,round,none|}\",",
+      "\t\tanchor: \"${6|bottom,center|}\",",
+      "\t\tprofileRotation: \"${7|all,heading|}\"",
+      "\t})]",
+      "})"
+    ],
+    "description": "Generate LineSymbol3D with a PathSymbol3DLayer",
+    "prefix": "path"
+  },
+  "PictureFillSymbol": {
+    "body": [
+      "const pfs = new PictureFillSymbol({",
+      "  url: \"image-url\",",
+      "  width: 12,",
+      "  height: 12,",
+      "  xoffset: 0,",
+      "  yoffset: 0",
+      "});"
+    ],
+    "prefix": "pfs"
+  },
+  "PictureMarkerSymbol": {
+    "body": [
+      "const pms = new PictureMarkerSymbol({",
+      "  url: \"image-url\",",
+      "  height: 12,",
+      "  width: 12",
+      "});"
+    ],
+    "description": "Create a PictureMarkerSymbol",
+    "prefix": "pms"
+  },
+  "SceneBackground": {
+    "body": [
+      "environment: {",
+      "\tbackground: {",
+      "\t\ttype: \"color\",",
+      "\t\tcolor: ${1:[0, 0, 0, 0]}",
+      "\t},",
+      "\tstarsEnabled: false,",
+      "\tatmosphereEnabled: false",
+      "}"
+    ],
+    "description": "Change the background of a scene",
+    "prefix": "background"
+  },
+  "SimpleFillSymbol": {
+    "body": [
+      "const sfs = new SimpleFillSymbol({",
+      "  color: [0, 0, 0, 0.25],",
+      "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "});"
+    ],
+    "description": "Create a SimpleFillSymbol",
+    "prefix": "sfs"
+  },
+  "SimpleLineSymbol": {
+    "body": [
+      "const sls = new SimpleLineSymbol({",
+      "  width: 1,",
+      "  color: [255, 255, 255, 1],",
+      "  style: \"${1|solid,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,none,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
+      "  cap: \"${2|round,butt,square|}\",",
+      "  join: \"${3|round,miter,bevel|}\"",
+      "});"
+    ],
+    "description": "Create a SimpleLineSymbol",
+    "prefix": "sls"
+  },
+  "SimpleMarkerSymbol": {
+    "body": [
+      "const sms = new SimpleMarkerSymbol({",
+      "  color: [255, 255, 255, 0.25],",
+      "  size: 12,",
+      "  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",
+      "  outline: {",
+      "    width: 1,",
+      "    color: [255, 255, 255, 1]",
+      "  }",
+      "});"
+    ],
+    "description": "Create a SimpleMarkerSymbol",
+    "prefix": "sms"
+  },
+  "SimpleRenderer": {
+    "body": [
+      "new SimpleRenderer({",
+      "\tsymbol: ${1:symbol}",
+      "})"
+    ],
+    "description": "Generate a SimpleRenderer",
+    "prefix": "simple"
+  },
+  "SizeVisualVariable": {
+    "body": [
+      "new SizeVariable({",
+      "\tfield: \"${1:POP_POVERTY}\",",
+      "\tnormalizationField: \"${2:POP_TOT}\",",
+      "\taxis: \"height\",",
+      "\tlegendOptions: {",
+      "\t\ttitle: \"${3:% population in poverty by county}\"",
+      "\t},",
+      "\tstops: [",
+      "\t\t{ value: ${4:0.15}, size: ${5:4}, label: \"${6:<15%}\" },",
+      "\t\t{ value: ${7:0.25}, size: ${8:12}, label: \"${9:25%}\" }",
+      "\t]",
+      "})"
+    ],
+    "description": "Generate a SizeVisualVariable.",
+    "prefix": "sizeVar"
+  },
+  "SketchEdges": {
+    "body": [
+      "new SketchEdges3D({",
+      "\tcolor: ${1:[50, 50, 50, 0.5]},",
+      "\tsize: ${2:1},",
+      "\textensionLength: ${3:0}",
+      "})"
+    ],
+    "prefix": "sketchEdges"
+  },
+  "SolidEdges": {
+    "body": [
+      "new SolidEdges3D({",
+      "\tcolor: ${1:[50, 50, 50, 0.5]},",
+      "\tsize: ${2:1}",
+      "})"
+    ],
+    "prefix": "solidEdges"
+  },
+  "UniqueValueRenderer": {
+    "body": [
+      "new UniqueValueRenderer({",
+      "\tfield: \"${1:REGION}\",",
+      "\tdefaultSymbol: ${2:symbol},",
+      "\tuniqueValueInfos: [{",
+      "\t\tvalue: \"${3:value}\",",
+      "\t\tsymbol: ${2:symbol},",
+      "\t\tlabel: \"${4:label for the legend}\"",
+      "\t}]",
+      "})"
+    ],
+    "description": "Generate a UniqueValueRenderer",
+    "prefix": "uniqueValue"
   }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -177,7 +177,7 @@
   },
   "FeatureReductionCluster": {
     "body": [
-      "const featureReduction = new FeatureReductionCluster({",
+      "new FeatureReductionCluster({",
       "  clusterRadius: 60,",
       "  clusterMinSize: 16.5,",
       "  clusterMaxSize: 37.5,",
@@ -355,7 +355,7 @@
   },
   "PictureFillSymbol": {
     "body": [
-      "const pfs = new PictureFillSymbol({",
+      "new PictureFillSymbol({",
       "  url: \"image-url\",",
       "  width: 12,",
       "  height: 12,",
@@ -367,7 +367,7 @@
   },
   "PictureMarkerSymbol": {
     "body": [
-      "const pms = new PictureMarkerSymbol({",
+      "new PictureMarkerSymbol({",
       "  url: \"image-url\",",
       "  height: 12,",
       "  width: 12",
@@ -392,7 +392,7 @@
   },
   "SimpleFillSymbol": {
     "body": [
-      "const sfs = new SimpleFillSymbol({",
+      "new SimpleFillSymbol({",
       "  color: [0, 0, 0, 0.25],",
       "  style: \"${1|solid,backward-diagonal,cross,diagonal-cross,forward-diagonal,horizontal,none,vertical|}\",",
       "  outline: {",
@@ -406,7 +406,7 @@
   },
   "SimpleLineSymbol": {
     "body": [
-      "const sls = new SimpleLineSymbol({",
+      "new SimpleLineSymbol({",
       "  width: 1,",
       "  color: [255, 255, 255, 1],",
       "  style: \"${1|solid,dash,dash-dot,dot,long-dash,long-dash-dot,long-dash-dot-dot,none,short-dash,short-dash-dot,short-dash-dot-dot,short-dot|}\",",
@@ -419,7 +419,7 @@
   },
   "SimpleMarkerSymbol": {
     "body": [
-      "const sms = new SimpleMarkerSymbol({",
+      "new SimpleMarkerSymbol({",
       "  color: [255, 255, 255, 0.25],",
       "  size: 12,",
       "  style: \"${1|circle,square,cross,x,diamond,triangle,path|}\",",


### PR DESCRIPTION
This PR adds JS and TS snippets for 2D symbols and clustering:

- SimpleMarkerSymbol
- PictureMarkerSymbol
- SimpleLineSymbol
- SimpleFillSymbol
- PictureFillSymbol
- FeatureReductionCluster

It also re-orders all snippets to follow ABC order.

@kellyhutchins will you review?

Since the re-ordering will make it a little difficult to see the new snippets, you can review them here: https://github.com/Esri/arcgis-js-vscode-snippets/commit/fbbb600dda0cc5cd522cb03875dbfdfd57eedccc

If the snippet reordering is too problematic, I can revert that commit and keep this PR only about the new snippets.

cc @RalucaNicola 