### PR TITLE
update jsapi version in getApi snippet

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -1,10 +1,9 @@
 {
- 
   "Get the API from the CDN": {
     "prefix": "getApi",
     "body": [
-      "<link rel=\"stylesheet\" href=\"https://js.arcgis.com/${1|4.27,4.26,4.25,4.24,4.23,4.22,4.21,4.20,4.19,4.18,4.17,4.16,1.15,4.14|}/esri/css/main.css\">",
-      "<script src=\"https://js.arcgis.com/${2|4.27,4.26,4.25,4.24,4.23,4.22,4.21,4.20,4.19,4.18,4.17,4.16,4.15,4.14|}\"></script>"
+      "<link rel=\"stylesheet\" href=\"https://js.arcgis.com/${1|4.28,4.27,4.26,4.25,4.24,4.23,4.22,4.21,4.20,4.19,4.18,4.17,4.16,1.15,4.14|}/esri/css/main.css\">",
+      "<script src=\"https://js.arcgis.com/${2|4.28,4.27,4.26,4.25,4.24,4.23,4.22,4.21,4.20,4.19,4.18,4.17,4.16,4.15,4.14|}\"></script>"
     ],
     "description": "Add script and link tags for jsapi"
   },
@@ -23,5 +22,4 @@
     ],
     "description": "Sets /app folder to be able to load packages using require([\"app/your_file.js\"]);"
   }
-
 }


### PR DESCRIPTION
Adds the latest [jsapi version](https://developers.arcgis.com/javascript/latest/release-notes/) to the getApi html snippet